### PR TITLE
issue 12: added error log file for unhandled exceptions

### DIFF
--- a/GitMemory/GitMemory.Application/Commands/ErrorLogCommand.cs
+++ b/GitMemory/GitMemory.Application/Commands/ErrorLogCommand.cs
@@ -1,0 +1,17 @@
+﻿using GitMemory.Application.Interfaces;
+using GitMemory.Domain.UI;
+
+namespace GitMemory.Application.Commands
+{
+    public class ErrorLogCommand : IGitCommandRequest
+    {
+        public List<string> Parameters { get; set; }
+        public IInteractionWindow InteractionWindow { get; set; }
+
+        public ErrorLogCommand(List<string> parameters, IInteractionWindow logger)
+        {
+            Parameters = parameters;
+            InteractionWindow = logger;
+        }
+    }
+}

--- a/GitMemory/GitMemory.Application/Configuration/ServiceExtensions.cs
+++ b/GitMemory/GitMemory.Application/Configuration/ServiceExtensions.cs
@@ -21,6 +21,7 @@ namespace GitMemory.Application.Configuration
         {
             services.AddScoped<IRequestHandler<SetRepoCommand, CommandResponse>, SetRepoCommandHandler>();
             services.AddScoped<IRequestHandler<PickCommand, CommandResponse>, PickCommandHandler>();
+            services.AddScoped<IRequestHandler<ErrorLogCommand, CommandResponse>, ErrorLogCommandHandler>();
             services.AddScoped<IPickCommandService, PickCommandService>();
             services.AddScoped<ISetRepoCommandService, SetRepoCommandService>();
             services.AddScoped<IGitMemoryGlobalSettings, GitMemoryGlobalSettings>();
@@ -28,6 +29,9 @@ namespace GitMemory.Application.Configuration
             services.AddScoped<ISettingsService, SettingsService>();
             services.AddScoped<IMemoryPoolService, MemoryPoolService>();
             services.AddScoped<IMemoryPoolRepository, MemoryPoolRepository>();
+            services.AddScoped<IErrorLogRepository, ErrorLogRepository>();
+            services.AddScoped<IErrorLogService, ErrorLogService>();
+
             return services;
         }
     }

--- a/GitMemory/GitMemory.Application/Handlers/ErrorLogCommandHandler.cs
+++ b/GitMemory/GitMemory.Application/Handlers/ErrorLogCommandHandler.cs
@@ -1,0 +1,39 @@
+﻿using GitMemory.Application.Commands;
+using GitMemory.Domain.Entities;
+using GitMemory.Domain.Entities.Enums;
+using GitMemory.Domain.Repositories;
+using GitMemory.Domain.Service.SetRepo;
+using MediatR;
+
+namespace GitMemory.Application.Handlers
+{
+    public class ErrorLogCommandHandler : IRequestHandler<ErrorLogCommand, CommandResponse>
+    {
+        private readonly ISettingsService _settingsService;        
+
+        public ErrorLogCommandHandler(ISetRepoCommandService commandService, ISettingsService settingsService)
+        {
+            _settingsService = settingsService;
+        }
+
+        public async Task<CommandResponse> Handle(ErrorLogCommand request, CancellationToken cancellationToken)
+        {
+            if (request.Parameters is not null && !String.IsNullOrEmpty(request.Parameters.FirstOrDefault())
+                && request.Parameters.Count > 0)
+            {
+                if (request.Parameters.FirstOrDefault()!.Trim().ToLower().Equals("--enable"))
+                {
+                    return await _settingsService.EnableErrorLogs();                    
+                }
+                else
+                if (request.Parameters.FirstOrDefault()!.Trim().ToLower().Equals("--disable"))
+                {
+                    return await _settingsService.DisableErrorLogs();                    
+                }
+                else
+                    return await Task.FromResult(new CommandResponse($"Invalid parameter{request.Parameters.FirstOrDefault()}", ResponseTypeEnum.Error));
+            }
+            return await Task.FromResult(new CommandResponse($"Missing parameter `--enable` or `--disable` for command `errorlog`", ResponseTypeEnum.Error));
+        }
+    }
+}

--- a/GitMemory/GitMemory.Application/Handlers/SetRepoCommandHandler.cs
+++ b/GitMemory/GitMemory.Application/Handlers/SetRepoCommandHandler.cs
@@ -25,7 +25,7 @@ namespace GitMemory.Application.Handlers
                 !globalSettings.RepositoryLocation.Equals(request.Parameters.FirstOrDefault()))
             {   
                 request.InteractionWindow.Write(new CommandResponse($"Current Location: {globalSettings.RepositoryLocation}", ResponseTypeEnum.Info));
-                var dialogResult = request.InteractionWindow.Read(DialogButtonsEnum.YesNo, new CommandResponse("Warning: A repository is already set for this user. Do you want to overwrite the current set location? Y/N", ResponseTypeEnum.Warning));
+                var dialogResult = request.InteractionWindow.Read(DialogButtonsEnum.YesNo, new CommandResponse("Warning: A repository is already set for this user. Do you want to overwrite the current location set?", ResponseTypeEnum.Warning));
                 if (dialogResult == DialogResultEnum.No)
                     return await Task.FromResult(new CommandResponse("No repository changes.", ResponseTypeEnum.Info));
             }

--- a/GitMemory/GitMemory.ConsoleApp/CommandUI.cs
+++ b/GitMemory/GitMemory.ConsoleApp/CommandUI.cs
@@ -39,6 +39,8 @@ namespace GitMemory.ConsoleApp
                     return new SetRepoCommand(Args.Skip(1).ToList(), _interactionWindow);
                 if (Args.First().ToLower().Equals("pick"))
                     return new PickCommand(Args.Skip(1).ToList(), _interactionWindow);
+                if (Args.First().ToLower().Equals("errorlog"))
+                    return new ErrorLogCommand(Args.Skip(1).ToList(), _interactionWindow);
                 else
                     throw new ArgumentException("Invalid command.");
             }

--- a/GitMemory/GitMemory.ConsoleApp/Program.cs
+++ b/GitMemory/GitMemory.ConsoleApp/Program.cs
@@ -23,7 +23,7 @@ class Program
 
         var app = new CommandUI(serviceProvider.GetRequiredService<IMediator>(), new UserInteraction());
         //app.Args = args.ToList();
-        app.Args = new List<string>() { "pick", "C:\\Repos\\git-memory\\test" };
+        app.Args = new List<string>() { "pick", "AKSJDLKADSKLAMDKLAMD" };
         await app.Run();
     }
 }

--- a/GitMemory/GitMemory.Domain/Entities/Enums/GlobalSettingsEnum.cs
+++ b/GitMemory/GitMemory.Domain/Entities/Enums/GlobalSettingsEnum.cs
@@ -9,5 +9,6 @@
     {
         public const string RepositoryLocationItemKey = "repository";
         public const string ConfigurationFileLocationItemKey = "configurationFile";
+        public const string ErrorLogItemKey = "errorLog";
     }
 }

--- a/GitMemory/GitMemory.Domain/Entities/GlobalSettings.cs
+++ b/GitMemory/GitMemory.Domain/Entities/GlobalSettings.cs
@@ -4,5 +4,6 @@
     {
         public string RepositoryLocation { get; set; } = String.Empty;
         public string ConfigurationFileLocation { get; set; } = String.Empty;
+        public bool IsErrorLogsEnabled { get; set; }
     }
 }

--- a/GitMemory/GitMemory.Domain/Repositories/IErrorLogRepository.cs
+++ b/GitMemory/GitMemory.Domain/Repositories/IErrorLogRepository.cs
@@ -1,0 +1,10 @@
+﻿using GitMemory.Domain.Entities.Memories;
+
+namespace GitMemory.Domain.Repositories
+{
+    public interface IErrorLogRepository
+    {
+        void Log(string message);
+        void Log(Exception ex);
+    }
+}

--- a/GitMemory/GitMemory.Domain/Repositories/IGitMemoryGlobalSettings.cs
+++ b/GitMemory/GitMemory.Domain/Repositories/IGitMemoryGlobalSettings.cs
@@ -14,5 +14,6 @@ namespace GitMemory.Domain.Repositories
         void WriteValue(string section, string property, string value, string defaultValue);
         string? ReadValue(string section, string property);
         GlobalSettings ReadGlobalSettings();
+        public string FileName { get; set; }
     }
 }

--- a/GitMemory/GitMemory.Domain/Repositories/IMemoryPoolRepository.cs
+++ b/GitMemory/GitMemory.Domain/Repositories/IMemoryPoolRepository.cs
@@ -6,5 +6,6 @@ namespace GitMemory.Domain.Repositories
     {
         MemoryPool? ReadMemoryPool();
         void WriteMemoryPool(MemoryPool memoryPool);
+        string FileName { get; set; }
     }
 }

--- a/GitMemory/GitMemory.Domain/Repositories/ISettingsService.cs
+++ b/GitMemory/GitMemory.Domain/Repositories/ISettingsService.cs
@@ -20,6 +20,8 @@ namespace GitMemory.Domain.Repositories
 
         // user settings
         FileInfo CreateUserSettingsJson(string folder);
-        DirectoryInfo CreateUserSettingsFolder(string folderPath);        
+        DirectoryInfo CreateUserSettingsFolder(string folderPath);
+        Task<CommandResponse> EnableErrorLogs();
+        Task<CommandResponse> DisableErrorLogs();
     }
 }

--- a/GitMemory/GitMemory.Domain/Service/IErrorLogService.cs
+++ b/GitMemory/GitMemory.Domain/Service/IErrorLogService.cs
@@ -1,0 +1,15 @@
+﻿using GitMemory.Domain.Entities.Memories;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GitMemory.Domain.Service
+{
+    public interface IErrorLogService
+    {
+        void Log(string message);
+        void Log(Exception ex);
+    }
+}

--- a/GitMemory/GitMemory.Infrastructure/CommandsServices/ErrorLogService.cs
+++ b/GitMemory/GitMemory.Infrastructure/CommandsServices/ErrorLogService.cs
@@ -1,0 +1,25 @@
+﻿using GitMemory.Domain.Entities.Memories;
+using GitMemory.Domain.Repositories;
+using GitMemory.Domain.Service;
+
+namespace GitMemory.Infrastructure.CommandsServices
+{
+    public class ErrorLogService : IErrorLogService
+    {
+        private readonly IErrorLogRepository _errorLogRepository;
+        public ErrorLogService(IErrorLogRepository repository)
+        {
+            _errorLogRepository = repository;
+        }
+
+        public void Log(string message)
+        {
+            _errorLogRepository.Log(message);
+        }
+
+        public void Log(Exception ex)
+        {
+            _errorLogRepository.Log(ex);
+        }
+    }
+}

--- a/GitMemory/GitMemory.Infrastructure/CommandsServices/Pick/PickCommandService.cs
+++ b/GitMemory/GitMemory.Infrastructure/CommandsServices/Pick/PickCommandService.cs
@@ -9,10 +9,12 @@ namespace GitMemory.Infrastructure.CommandsServices.Pick
     public class PickCommandService : IPickCommandService
     {
         private readonly IMemoryPoolRepository _memoryPoolRepository;
+        private readonly IErrorLogRepository _errorLogRepository;
         private IPickStrategy _pickStrategy = null!;
-        public PickCommandService(IMemoryPoolRepository memoryPoolRepository)
+        public PickCommandService(IMemoryPoolRepository memoryPoolRepository, IErrorLogRepository errorLogRepository)
         {
             _memoryPoolRepository = memoryPoolRepository;
+            _errorLogRepository = errorLogRepository;
         }
 
         public Task<CommandResponse> ExecuteCommand(List<string> commands, bool clearPoolList)
@@ -25,7 +27,7 @@ namespace GitMemory.Infrastructure.CommandsServices.Pick
                 if (clearPoolList)
                     memoryPool = ClearPoolList(memoryPool);
                 var isInteger = int.TryParse(commands.FirstOrDefault(), out int result);
-                _pickStrategy = isInteger ? new PickByNumber(_memoryPoolRepository) : new PickByList(_memoryPoolRepository);
+                _pickStrategy = isInteger ? new PickByNumber(_memoryPoolRepository, _errorLogRepository) : new PickByList(_memoryPoolRepository, _errorLogRepository);
                 return _pickStrategy.Execute(commands, memoryPool);
             }
             catch (Exception ex)

--- a/GitMemory/GitMemory.Infrastructure/CommandsServices/SetRepo/SetRepoCommandService.cs
+++ b/GitMemory/GitMemory.Infrastructure/CommandsServices/SetRepo/SetRepoCommandService.cs
@@ -43,6 +43,7 @@ namespace GitMemory.Infrastructure.CommandsServices.SetRepo
                         _globalSettingsService.CreateGlobalSettingsJson();
                         _globalSettingsService.WriteValue(GlobalSettingsSections.UserSectionKey, GlobalSettingsItems.RepositoryLocationItemKey, repositoryFolder, "");
                         _globalSettingsService.WriteValue(GlobalSettingsSections.UserSectionKey, GlobalSettingsItems.ConfigurationFileLocationItemKey, configurationJsonFile.FullName, "");
+                        _globalSettingsService.WriteValue(GlobalSettingsSections.UserSectionKey, GlobalSettingsItems.ErrorLogItemKey, "FALSE", "");
                         return Task.FromResult(new CommandResponse($"Folder created successfully."));
                     }
                     else

--- a/GitMemory/GitMemory.Infrastructure/CommandsServices/SettingsService.cs
+++ b/GitMemory/GitMemory.Infrastructure/CommandsServices/SettingsService.cs
@@ -48,6 +48,32 @@ namespace GitMemory.Infrastructure.CommandsServices
         {
             return _globalSettingsRepository.GetGlobalSettingsFilePath();
         }
+        public Task<CommandResponse> EnableErrorLogs()
+        {
+            try
+            {
+                WriteGlobalSettingsValue(GlobalSettingsSections.UserSectionKey, GlobalSettingsItems.ErrorLogItemKey, "TRUE", "");
+                return Task.FromResult(new CommandResponse($"Error Logs enabled.", ResponseTypeEnum.Info));
+            }
+            catch {
+                return Task.FromResult(new CommandResponse("EnableErrorLogs: Unable to enable error logs", ResponseTypeEnum.Error));
+            }
+        }
+
+
+        public Task<CommandResponse> DisableErrorLogs()
+        {
+            try
+            {
+                WriteGlobalSettingsValue(GlobalSettingsSections.UserSectionKey, GlobalSettingsItems.ErrorLogItemKey, "FALSE", "");
+                return Task.FromResult(new CommandResponse($"Error Logs disabled.", ResponseTypeEnum.Info));
+            }
+            catch
+            {
+                return Task.FromResult(new CommandResponse("EnableErrorLogs: Unable to disable error logs", ResponseTypeEnum.Error));
+            }
+            
+        }
 
         // user settings
 

--- a/GitMemory/GitMemory.Infrastructure/Repositories/ErrorLogRepository.cs
+++ b/GitMemory/GitMemory.Infrastructure/Repositories/ErrorLogRepository.cs
@@ -1,0 +1,77 @@
+﻿using GitMemory.Domain.Entities.Memories;
+using GitMemory.Domain.Repositories;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace GitMemory.Infrastructure.Repositories
+{
+    public class ErrorLogRepository : IErrorLogRepository
+    {
+        private readonly string _filePath;
+        private readonly bool _errorLogsEnabled;
+        public ErrorLogRepository(IGitMemoryGlobalSettings globalSettings)
+        {
+            _filePath = globalSettings.ReadGlobalSettings().RepositoryLocation ?? Directory.GetCurrentDirectory() ?? "";
+            _filePath += $"\\{DateTime.Now:yyyy-MM-dd}-errors.log";
+            _errorLogsEnabled = globalSettings.ReadGlobalSettings().IsErrorLogsEnabled;
+        }
+
+        public void Log(string message)
+        {
+            if (!_errorLogsEnabled)
+                return;
+            if (String.IsNullOrEmpty(_filePath))
+                return;
+            try
+            {
+                var directory = Path.GetDirectoryName(_filePath);
+                if (!Directory.Exists(directory))
+                {
+                    if (directory == null)
+                        return;
+                    Directory.CreateDirectory(directory);
+                }                
+                using (StreamWriter writer = new StreamWriter(_filePath, true))
+                {
+                    writer.WriteLine($"{DateTime.Now:yyyy-MM-dd HH:mm:ss} - {message}");
+                }
+            }
+            catch (Exception)
+            {
+                throw new Exception("Unable to write in error log file. Execute the command 'git memory errorlog --disable' to turn error logs off");
+            }
+        }
+
+        public void Log(Exception ex)
+        {
+            if (!_errorLogsEnabled)
+                return;
+            string exceptionMessage = FormatException(ex);
+            Log(exceptionMessage);
+        }
+
+        private string FormatException(Exception ex)
+        {
+            var sb = new StringBuilder();
+
+            sb.AppendLine($"Exception: {ex.GetType().FullName}");
+            sb.AppendLine($"Message: {ex.Message}");
+            sb.AppendLine($"Source: {ex.Source}");
+            sb.AppendLine($"Stack Trace: {ex.StackTrace}");
+
+            if (ex.InnerException != null)
+            {
+                sb.AppendLine("Inner Exception:");
+                sb.AppendLine($"Exception: {ex.InnerException.GetType().FullName}");
+                sb.AppendLine($"Message: {ex.InnerException.Message}");
+                sb.AppendLine($"Source: {ex.InnerException.Source}");
+                sb.AppendLine($"Stack Trace: {ex.InnerException.StackTrace}");
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/GitMemory/GitMemory.Infrastructure/Repositories/UserSettings.cs
+++ b/GitMemory/GitMemory.Infrastructure/Repositories/UserSettings.cs
@@ -9,6 +9,11 @@ namespace GitMemory.Infrastructure.Services
 {
     public class UserSettings : IUserSettings
     {
+        private readonly IErrorLogRepository _errorLogRepository;
+        public UserSettings(IErrorLogRepository errorLogRepository)
+        {
+            _errorLogRepository = errorLogRepository;
+        }
         public FileInfo CreateUserSettingsJson(string folder)
         {
             try
@@ -18,8 +23,9 @@ namespace GitMemory.Infrastructure.Services
                     File.Create(filePath).Close();
                 return new FileInfo(filePath);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                _errorLogRepository.Log(ex);
                 throw new Exception($"Error creating file in git-memory.json in {folder}");
             }
         }
@@ -33,16 +39,25 @@ namespace GitMemory.Infrastructure.Services
                     return Directory.CreateDirectory(gitMemoryFolder);
                 return new DirectoryInfo(gitMemoryFolder);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                _errorLogRepository.Log(ex);
                 throw new Exception($"Error creating directory in {folderPath}");
             }
         }
 
         public void HideFile(string folderPath)
         {
-            FileAttributes attributes = File.GetAttributes(folderPath);
-            File.SetAttributes(folderPath, attributes | FileAttributes.Hidden);
+            try
+            {
+                FileAttributes attributes = File.GetAttributes(folderPath);
+                File.SetAttributes(folderPath, attributes | FileAttributes.Hidden);
+            }
+            catch (Exception ex)
+            {
+                _errorLogRepository.Log(ex);
+                throw new Exception($"Error trying to hide folder {folderPath}");
+            }
         }
     }
 }


### PR DESCRIPTION
- Log files are saved inside the structure of Memories folder, in .gitmemory folder.
- The name of error logs follow the name convention `yyyy-MM-dd-error.log`
- Logs can be enabled/disabled using the commands:
  - `git memory errorlog --enable`
  - `git memory errorlog --disable`
- Logs were added to the existing unhandled exceptions.
- GlobalConfig file name is now replaceable
- Memories mapping file name is now replaceable