### PR TITLE
issue #7: added unpick command

### DIFF
--- a/GitMemory/GitMemory.Application/Commands/UnpickCommand.cs
+++ b/GitMemory/GitMemory.Application/Commands/UnpickCommand.cs
@@ -1,0 +1,17 @@
+﻿using GitMemory.Application.Interfaces;
+using GitMemory.Domain.UI;
+
+namespace GitMemory.Application.Commands
+{
+    public class UnpickCommand : IGitCommandRequest
+    {
+        public List<string> Parameters { get; set; }
+        public IInteractionWindow InteractionWindow { get; set; }
+
+        public UnpickCommand(List<string> parameters, IInteractionWindow logger)
+        {
+            Parameters = parameters;
+            InteractionWindow = logger;
+        }
+    }
+}

--- a/GitMemory/GitMemory.Application/Configuration/ServiceExtensions.cs
+++ b/GitMemory/GitMemory.Application/Configuration/ServiceExtensions.cs
@@ -5,9 +5,11 @@ using GitMemory.Domain.Repositories;
 using GitMemory.Domain.Service;
 using GitMemory.Domain.Service.Pick;
 using GitMemory.Domain.Service.SetRepo;
+using GitMemory.Domain.Service.Unpick;
 using GitMemory.Infrastructure.CommandsServices;
 using GitMemory.Infrastructure.CommandsServices.Pick;
 using GitMemory.Infrastructure.CommandsServices.SetRepo;
+using GitMemory.Infrastructure.CommandsServices.Unpick;
 using GitMemory.Infrastructure.Repositories;
 using GitMemory.Infrastructure.Services;
 using MediatR;
@@ -21,8 +23,10 @@ namespace GitMemory.Application.Configuration
         {
             services.AddScoped<IRequestHandler<SetRepoCommand, CommandResponse>, SetRepoCommandHandler>();
             services.AddScoped<IRequestHandler<PickCommand, CommandResponse>, PickCommandHandler>();
+            services.AddScoped<IRequestHandler<UnpickCommand, CommandResponse>, UnpickCommandHandler>();
             services.AddScoped<IRequestHandler<ErrorLogCommand, CommandResponse>, ErrorLogCommandHandler>();
             services.AddScoped<IPickCommandService, PickCommandService>();
+            services.AddScoped<IUnpickCommandService, UnpickCommandService>();
             services.AddScoped<ISetRepoCommandService, SetRepoCommandService>();
             services.AddScoped<IGitMemoryGlobalSettings, GitMemoryGlobalSettings>();
             services.AddScoped<IUserSettings, UserSettings>();
@@ -31,7 +35,6 @@ namespace GitMemory.Application.Configuration
             services.AddScoped<IMemoryPoolRepository, MemoryPoolRepository>();
             services.AddScoped<IErrorLogRepository, ErrorLogRepository>();
             services.AddScoped<IErrorLogService, ErrorLogService>();
-
             return services;
         }
     }

--- a/GitMemory/GitMemory.Application/Handlers/UnpickCommandHandler.cs
+++ b/GitMemory/GitMemory.Application/Handlers/UnpickCommandHandler.cs
@@ -1,0 +1,26 @@
+﻿using GitMemory.Application.Commands;
+using GitMemory.Domain.Entities;
+using GitMemory.Domain.Service;
+using GitMemory.Domain.Service.Unpick;
+using MediatR;
+
+namespace GitMemory.Application.Handlers
+{
+    public class UnpickCommandHandler : IRequestHandler<UnpickCommand, CommandResponse>
+    {
+        private readonly IMemoryPoolService _memoryPoolService;
+        private readonly IUnpickCommandService _unpickCommandService;
+        public UnpickCommandHandler(IMemoryPoolService memoryPoolService, IUnpickCommandService unpickCommandService)
+        {
+            _memoryPoolService = memoryPoolService;
+            _unpickCommandService = unpickCommandService;
+        }
+
+        public async Task<CommandResponse> Handle(UnpickCommand request, CancellationToken cancellationToken)
+        {
+            return await _unpickCommandService.ExecuteCommand(request.Parameters);
+        }
+
+        
+    }
+}

--- a/GitMemory/GitMemory.ConsoleApp/CommandUI.cs
+++ b/GitMemory/GitMemory.ConsoleApp/CommandUI.cs
@@ -39,6 +39,8 @@ namespace GitMemory.ConsoleApp
                     return new SetRepoCommand(Args.Skip(1).ToList(), _interactionWindow);
                 if (Args.First().ToLower().Equals("pick"))
                     return new PickCommand(Args.Skip(1).ToList(), _interactionWindow);
+                if (Args.First().ToLower().Equals("unpick"))
+                    return new UnpickCommand(Args.Skip(1).ToList(), _interactionWindow);
                 if (Args.First().ToLower().Equals("errorlog"))
                     return new ErrorLogCommand(Args.Skip(1).ToList(), _interactionWindow);
                 else

--- a/GitMemory/GitMemory.Domain/Service/Unpick/IUnpickCommandService.cs
+++ b/GitMemory/GitMemory.Domain/Service/Unpick/IUnpickCommandService.cs
@@ -1,0 +1,9 @@
+﻿using GitMemory.Domain.Entities;
+
+namespace GitMemory.Domain.Service.Unpick
+{
+    public interface IUnpickCommandService
+    {
+        Task<CommandResponse> ExecuteCommand(List<string> commands);
+    }
+}

--- a/GitMemory/GitMemory.Infrastructure/CommandsServices/Unpick/UnpickCommandService.cs
+++ b/GitMemory/GitMemory.Infrastructure/CommandsServices/Unpick/UnpickCommandService.cs
@@ -1,0 +1,39 @@
+﻿using GitMemory.Domain.Entities;
+using GitMemory.Domain.Entities.Enums;
+using GitMemory.Domain.Repositories;
+using GitMemory.Domain.Service.Unpick;
+using GitMemory.Infrastructure.CommandsServices.Unpick.UnpickStrategy;
+using GitMemory.Domain.Entities.Memories;
+namespace GitMemory.Infrastructure.CommandsServices.Unpick
+{
+    public class UnpickCommandService : IUnpickCommandService
+    {
+        private readonly IMemoryPoolRepository _memoryPoolRepository;
+        private readonly IErrorLogRepository _errorLogRepository;
+        private IUnpickStrategy _pickStrategy = null!;
+        public UnpickCommandService(IMemoryPoolRepository memoryPoolRepository, IErrorLogRepository errorLogRepository)
+        {
+            _memoryPoolRepository = memoryPoolRepository;
+            _errorLogRepository = errorLogRepository;
+        }
+
+        public Task<CommandResponse> ExecuteCommand(List<string> commands)
+        {
+            try
+            {
+                if (commands == null || commands.Count == 0)
+                    return Task.FromResult(new CommandResponse("No arguments provided.", ResponseTypeEnum.Error));
+                var memoryPool = _memoryPoolRepository.ReadMemoryPool() ?? new MemoryPool();
+                if (commands.FirstOrDefault()!.Equals(".") || commands.FirstOrDefault()!.ToLower().Equals("--all"))
+                    _pickStrategy = new UnpickAll(_memoryPoolRepository, _errorLogRepository);
+                else
+                    _pickStrategy = new UnpickByList(_memoryPoolRepository, _errorLogRepository);                
+                return _pickStrategy.Execute(commands, memoryPool);
+            }
+            catch (Exception ex)
+            {
+                return Task.FromResult(new CommandResponse(ex.Message, ResponseTypeEnum.Error));
+            }
+        }       
+    }
+}

--- a/GitMemory/GitMemory.Infrastructure/CommandsServices/Unpick/UnpickStrategy/IUnpickStrategy.cs
+++ b/GitMemory/GitMemory.Infrastructure/CommandsServices/Unpick/UnpickStrategy/IUnpickStrategy.cs
@@ -1,0 +1,10 @@
+﻿using GitMemory.Domain.Entities;
+using GitMemory.Domain.Entities.Memories;
+
+namespace GitMemory.Infrastructure.CommandsServices.Unpick.UnpickStrategy
+{
+    internal interface IUnpickStrategy
+    {
+        Task<CommandResponse> Execute(List<string> arguments, MemoryPool memoryPool);
+    }
+}

--- a/GitMemory/GitMemory.Infrastructure/CommandsServices/Unpick/UnpickStrategy/UnpickAll.cs
+++ b/GitMemory/GitMemory.Infrastructure/CommandsServices/Unpick/UnpickStrategy/UnpickAll.cs
@@ -1,0 +1,43 @@
+﻿using GitMemory.Domain.Entities;
+using GitMemory.Domain.Entities.Enums;
+using GitMemory.Domain.Entities.Memories;
+using GitMemory.Domain.Repositories;
+
+namespace GitMemory.Infrastructure.CommandsServices.Unpick.UnpickStrategy
+{
+    internal class UnpickAll : IUnpickStrategy
+    {
+        private readonly IMemoryPoolRepository _memoryPoolRepository;
+        private readonly IErrorLogRepository _errorLogRepository;
+        public UnpickAll(IMemoryPoolRepository memoryPoolRepository, IErrorLogRepository errorLogRepository)
+        {
+            _memoryPoolRepository = memoryPoolRepository;
+            _errorLogRepository = errorLogRepository;
+        }
+        
+        public Task<CommandResponse> Execute(List<string> arguments, MemoryPool memoryPool)
+        {
+            try
+            {
+                var currentDirectory = Directory.GetCurrentDirectory() ?? "";
+                foreach (var repository in memoryPool.GitRepositories.Where(p => p.GitRepositoryPath.ToLower().StartsWith(currentDirectory.ToLower())))
+                {
+                    repository.Staged.Clear();
+                    repository.Unstaged.Clear();
+                }                
+                _memoryPoolRepository.WriteMemoryPool(memoryPool);
+                return Task.FromResult(new CommandResponse("All commits unpicked.", ResponseTypeEnum.Info));
+            }
+            catch (ArgumentException ex)
+            {
+                return Task.FromResult(new CommandResponse(ex.Message, ResponseTypeEnum.Error));
+            }
+            catch (Exception ex)
+            {
+                _errorLogRepository.Log(ex);
+                return Task.FromResult(new CommandResponse("An error occurred while attempting to unpick commits. Please refer to the error log for more details.", ResponseTypeEnum.Error));
+            }
+                
+        }
+    }
+}

--- a/GitMemory/GitMemory.Infrastructure/CommandsServices/Unpick/UnpickStrategy/UnpickByList.cs
+++ b/GitMemory/GitMemory.Infrastructure/CommandsServices/Unpick/UnpickStrategy/UnpickByList.cs
@@ -1,0 +1,48 @@
+﻿using GitMemory.Domain.Entities;
+using GitMemory.Domain.Entities.Enums;
+using GitMemory.Domain.Entities.Memories;
+using GitMemory.Domain.Repositories;
+
+namespace GitMemory.Infrastructure.CommandsServices.Unpick.UnpickStrategy
+{
+    internal class UnpickByList : IUnpickStrategy
+    {
+        private readonly IMemoryPoolRepository _memoryPoolRepository;
+        private readonly IErrorLogRepository _errorLogRepository;
+        public UnpickByList(IMemoryPoolRepository memoryPoolRepository, IErrorLogRepository errorLogRepository)
+        {
+            _memoryPoolRepository = memoryPoolRepository;
+            _errorLogRepository = errorLogRepository;
+        }
+
+        public Task<CommandResponse> Execute(List<string> hashes, MemoryPool memoryPool)
+        {
+            try
+            {
+                var currentDirectory = Directory.GetCurrentDirectory() ?? "";
+                foreach (var repository in memoryPool.GitRepositories.Where(p => p.GitRepositoryPath.ToLower().StartsWith(currentDirectory.ToLower())))
+                    foreach(var hash in hashes)
+                        RemoveIfExists(repository.Unstaged, repository.Staged, hash);
+                
+                _memoryPoolRepository.WriteMemoryPool(memoryPool);
+                return Task.FromResult(new CommandResponse("Commits unpicked.", ResponseTypeEnum.Info));
+            }
+            catch (ArgumentException ex)
+            {
+                return Task.FromResult(new CommandResponse(ex.Message, ResponseTypeEnum.Error));
+            }
+            catch (Exception ex)
+            {
+                _errorLogRepository.Log(ex);
+                return Task.FromResult(new CommandResponse("An error occurred while attempting to unpick commits. Please refer to the error log for more details.", ResponseTypeEnum.Error));
+            }
+                
+        }
+
+        private void RemoveIfExists(List<MemoryCommit> unstaged, List<MemoryCommit> staged, string hash)
+        {
+            staged.RemoveAll(commit => commit.CommitHash.Equals(hash));
+            unstaged.RemoveAll(commit => commit.CommitHash.Equals(hash));
+        }
+    }
+}


### PR DESCRIPTION
**Description**
New commands added:
1 - Remove all commits from staged/unstaged areas:
`git memory unpick --all` or `git memory unpick .`
2 - Remove commits by hash from staged/unstaged areas:
`git memory unpick <hash1> <hash2>`