### PR TITLE
#5: fixed setrepo warning message order

### DIFF
--- a/GitMemory/GitMemory.Application/Handlers/SetRepoCommandHandler.cs
+++ b/GitMemory/GitMemory.Application/Handlers/SetRepoCommandHandler.cs
@@ -24,8 +24,8 @@ namespace GitMemory.Application.Handlers
             if (!string.IsNullOrEmpty(globalSettings.RepositoryLocation) && 
                 !globalSettings.RepositoryLocation.Equals(request.Parameters.FirstOrDefault()))
             {
-                var dialogResult = CommandContextAccessor.Current.InteractionWindow.Read(DialogButtonsEnum.YesNo, new CommandResponse("Warning: A repository is already set in another location. Do you want to overwrite the current location set?", ResponseTypeEnum.Warning));
                 CommandContextAccessor.Current.InteractionWindow.Write(new CommandResponse($"Current Repository Location: {globalSettings.RepositoryLocation}", ResponseTypeEnum.Info));
+                var dialogResult = CommandContextAccessor.Current.InteractionWindow.Read(DialogButtonsEnum.YesNo, new CommandResponse("Warning: A repository is already set in another location. Do you want to overwrite the current location set?", ResponseTypeEnum.Warning));                
                 if (dialogResult == DialogResultEnum.No)
                     return await Task.FromResult(new CommandResponse("No repository changes.", ResponseTypeEnum.Info));
             }

--- a/GitMemory/GitMemory.ConsoleApp.IntegrationTests/Commands/SetRepo/SetRepoCommandTest.cs
+++ b/GitMemory/GitMemory.ConsoleApp.IntegrationTests/Commands/SetRepo/SetRepoCommandTest.cs
@@ -58,9 +58,9 @@ namespace GitMemory.ConsoleApp.IntegrationTests.Commands.SetRepo
             // Arrange
             var repoDirectory2 = Path.Combine(_commandTestFixture.TempDirectory, "repo2");
             Directory.CreateDirectory(repoDirectory2);
+            string expectedRepositoryInfo = $"Current Repository Location: {_commandTestFixture.RepoDirectory}"; // current applied repo check
             string expectedQuestion = "Warning: A repository is already set in another location. Do you want to overwrite the current location set?";
-            Interactions.DialogResultRequest.Enqueue(Domain.Entities.Enums.DialogResultEnum.Yes);
-            string expectedAnswer = $"Current Repository Location: {_commandTestFixture.RepoDirectory}"; // current applied repo check
+            Interactions.DialogResultRequest.Enqueue(Domain.Entities.Enums.DialogResultEnum.Yes);            
             string expectedResult = "Folder created successfully.";
 
             // Act
@@ -69,13 +69,13 @@ namespace GitMemory.ConsoleApp.IntegrationTests.Commands.SetRepo
                                                             "--CurrentDirectory", _commandTestFixture.CurrentDirectoryFolder });
 
             // Assert
+            var actualRepositoryInfo = Interactions.Output.Dequeue();
+            Assert.Equal(expectedRepositoryInfo, actualRepositoryInfo.Message);
+            Assert.Equal(Domain.Entities.Enums.ResponseTypeEnum.Info, actualRepositoryInfo.ResponseType);
+
             var actualQuestion = Interactions.Output.Dequeue();
             Assert.Equal(expectedQuestion, actualQuestion.Message);
-            Assert.Equal(Domain.Entities.Enums.ResponseTypeEnum.Warning, actualQuestion.ResponseType);
-
-            var actualAnswer = Interactions.Output.Dequeue();
-            Assert.Equal(expectedAnswer, actualAnswer.Message);
-            Assert.Equal(Domain.Entities.Enums.ResponseTypeEnum.Info, actualAnswer.ResponseType);
+            Assert.Equal(Domain.Entities.Enums.ResponseTypeEnum.Warning, actualQuestion.ResponseType);            
 
             var actualResult = Interactions.Output.Dequeue();
             Assert.Equal(expectedResult, actualResult.Message);
@@ -95,9 +95,9 @@ namespace GitMemory.ConsoleApp.IntegrationTests.Commands.SetRepo
             // Arrange
             var repoDirectory3 = Path.Combine(_commandTestFixture.TempDirectory, "repo3");
             Directory.CreateDirectory(repoDirectory3);
+            string expectedRepositoryInfo = $"Current Repository Location: {_commandTestFixture.RepoDirectory}"; // current applied repo check
             string expectedQuestion = "Warning: A repository is already set in another location. Do you want to overwrite the current location set?";
-            Interactions.DialogResultRequest.Enqueue(Domain.Entities.Enums.DialogResultEnum.No); // User Says No
-            string expectedAnswer = $"Current Repository Location: {_commandTestFixture.RepoDirectory}"; // current applied repo check
+            Interactions.DialogResultRequest.Enqueue(Domain.Entities.Enums.DialogResultEnum.No); // User Says No            
             string expectedResult = "No repository changes.";
 
             // Act
@@ -106,13 +106,13 @@ namespace GitMemory.ConsoleApp.IntegrationTests.Commands.SetRepo
                                                             "--CurrentDirectory", _commandTestFixture.CurrentDirectoryFolder });
 
             // Assert
+            var actualRepositoryInfo = Interactions.Output.Dequeue();
+            Assert.Equal(expectedRepositoryInfo, actualRepositoryInfo.Message);
+            Assert.Equal(Domain.Entities.Enums.ResponseTypeEnum.Info, actualRepositoryInfo.ResponseType);
+
             var actualQuestion = Interactions.Output.Dequeue();
             Assert.Equal(expectedQuestion, actualQuestion.Message);
-            Assert.Equal(Domain.Entities.Enums.ResponseTypeEnum.Warning, actualQuestion.ResponseType);
-
-            var actualAnswer = Interactions.Output.Dequeue();
-            Assert.Equal(expectedAnswer, actualAnswer.Message);
-            Assert.Equal(Domain.Entities.Enums.ResponseTypeEnum.Info, actualAnswer.ResponseType);
+            Assert.Equal(Domain.Entities.Enums.ResponseTypeEnum.Warning, actualQuestion.ResponseType);            
 
             var actualResultOutput = Interactions.Output.Dequeue();
             Assert.Equal(expectedResult, actualResultOutput.Message);
@@ -129,9 +129,9 @@ namespace GitMemory.ConsoleApp.IntegrationTests.Commands.SetRepo
             // Arrange
             var repoDirectoryDot = ".";
             Directory.CreateDirectory(repoDirectoryDot);
+            string expectedRepositoryInfo = $"Current Repository Location: {_commandTestFixture.RepoDirectory}"; // current applied repo check
             string expectedQuestion = "Warning: A repository is already set in another location. Do you want to overwrite the current location set?";
-            Interactions.DialogResultRequest.Enqueue(Domain.Entities.Enums.DialogResultEnum.Yes);
-            string expectedAnswer = $"Current Repository Location: {_commandTestFixture.RepoDirectory}"; // current applied repo check
+            Interactions.DialogResultRequest.Enqueue(Domain.Entities.Enums.DialogResultEnum.Yes);            
             string expectedResult = "Folder created successfully.";
 
             // Act
@@ -140,13 +140,13 @@ namespace GitMemory.ConsoleApp.IntegrationTests.Commands.SetRepo
                                                             "--CurrentDirectory", _commandTestFixture.CurrentDirectoryFolder });
 
             // Assert
+            var actualRepositoryInfo = Interactions.Output.Dequeue();
+            Assert.Equal(expectedRepositoryInfo, actualRepositoryInfo.Message);
+            Assert.Equal(Domain.Entities.Enums.ResponseTypeEnum.Info, actualRepositoryInfo.ResponseType);
+
             var actualQuestion = Interactions.Output.Dequeue();
             Assert.Equal(expectedQuestion, actualQuestion.Message);
-            Assert.Equal(Domain.Entities.Enums.ResponseTypeEnum.Warning, actualQuestion.ResponseType);
-
-            var actualCurrentRepoWarning = Interactions.Output.Dequeue();
-            Assert.Equal(expectedAnswer, actualCurrentRepoWarning.Message);
-            Assert.Equal(Domain.Entities.Enums.ResponseTypeEnum.Info, actualCurrentRepoWarning.ResponseType);
+            Assert.Equal(Domain.Entities.Enums.ResponseTypeEnum.Warning, actualQuestion.ResponseType);            
 
             var actualResult = Interactions.Output.Dequeue();
             Assert.Equal(expectedResult, actualResult.Message);

--- a/GitMemory/GitMemory.ConsoleApp.IntegrationTests/Configuration/Interactions.cs
+++ b/GitMemory/GitMemory.ConsoleApp.IntegrationTests/Configuration/Interactions.cs
@@ -8,6 +8,15 @@ using System.Threading.Tasks;
 
 namespace GitMemory.ConsoleApp.IntegrationTests.Configuration
 {
+    /// <summary>
+    /// All the interaction between a user and GitMemory will be simulated using these 3 queues.
+    /// So for every test where it's expected to happen an interaction, all the interactions should be included in one 
+    /// or more out of these queues.
+    /// 
+    /// - StringRequest: when it's requested a text answer from the User (repo location, argument value, etc)
+    /// - DialogResultRequest: when it's requested a default answer to the user  (yes/no/cancel/ok)
+    /// - Output: the message returned to the user (e.g: "Repository saved.")
+    /// </summary>
     public class Interactions
     {
         public static Queue<string> StringRequest { get; set; } = new Queue<string>();


### PR DESCRIPTION
- Fixed SetRepo command warning message order. Now "Current Repo" message info is send before warning.